### PR TITLE
Update Outputs to fix issue with License output, and add addtl output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,3 +37,6 @@
 ### Features
 - Adjusted Outputs to accomodate license resource added in ver 0.0.6
 - Added output for Socket Lan Route Table (lan_subnet_route_table_id) for use in upstream calls
+- Removed Management Route Table - No Longer Needed 
+- Updated Cato vSocket WAN Security Group to Remove Inbound Rules 
+- Updated Cato vSocket WAN Security Group to Add Outbound Rules (udp/443, tcp/443, udp/53, tcp/53)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,3 +31,9 @@
 ### Features
 - Adjusted Readme Example to Match Variable Name (vpc_range becomes native_network_range)
 - Disassociated native_network_range from vpc_cidr_range to enable VPC_CIDR to be different from Native_network_range
+
+## 0.0.8 (2025-05-09)
+
+### Features
+- Adjusted Outputs to accomodate license resource added in ver 0.0.6
+- Added output for Socket Lan Route Table (lan_subnet_route_table_id) for use in upstream calls

--- a/README.md
+++ b/README.md
@@ -138,10 +138,8 @@ Apache 2 Licensed. See [LICENSE](https://github.com/catonetworks/terraform-cato-
 | [aws_network_interface.mgmteni](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_interface) | resource |
 | [aws_network_interface.waneni](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_interface) | resource |
 | [aws_route.lan_route](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
-| [aws_route.mgmt_route](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route.wan_route](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route_table.lanrt](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
-| [aws_route_table.mgmtrt](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
 | [aws_route_table.wanrt](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
 | [aws_route_table_association.lan_subnet_route_table_association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
 | [aws_route_table_association.mgmt_subnet_route_table_association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |

--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Apache 2 Licensed. See [LICENSE](https://github.com/catonetworks/terraform-cato-
 | <a name="output_internet_gateway_id"></a> [internet\_gateway\_id](#output\_internet\_gateway\_id) | # The following attributes are exported: |
 | <a name="output_lan_eni_id"></a> [lan\_eni\_id](#output\_lan\_eni\_id) | n/a |
 | <a name="output_lan_subnet_id"></a> [lan\_subnet\_id](#output\_lan\_subnet\_id) | n/a |
+| <a name="output_lan_subnet_route_table_id"></a> [lan\_subnet\_route\_table\_id](#output\_lan\_subnet\_route\_table\_id) | n/a |
 | <a name="output_local_ip"></a> [local\_ip](#output\_local\_ip) | n/a |
 | <a name="output_mgmt_eip_id"></a> [mgmt\_eip\_id](#output\_mgmt\_eip\_id) | n/a |
 | <a name="output_mgmt_eni_id"></a> [mgmt\_eni\_id](#output\_mgmt\_eni\_id) | n/a |

--- a/outputs.tf
+++ b/outputs.tf
@@ -22,10 +22,6 @@ output "cato_site_name" { value = module.vsocket-aws.cato_site_name }
 output "native_network_range" { value = module.vsocket-aws.native_network_range }
 output "local_ip" { value = module.vsocket-aws.local_ip }
 output "cato_license_site" {
-  value = var.license_id == null ? null : {
-    id           = cato_license.license[0].id
-    license_id   = cato_license.license[0].license_id
-    license_info = cato_license.license[0].license_info
-    site_id      = cato_license.license[0].site_id
-  }
+  value = var.license_id == null ? null : module.vsocket-aws.cato_license_site
 }
+output "lan_subnet_route_table_id" { value = aws_route_table.lanrt.id }


### PR DESCRIPTION
Update Outputs 
1. Output for licensing was referencing a resource not defined in this module, updated to have it point at sub-module. 
2. Added output "lan_subnet_route_table_id" to enable orchestration of LAN Route Table in calling modules.