### PR TITLE
Update module for site_location, routed_networks, and code cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,3 +43,13 @@
 
 ## 0.0.9
  - Added output to get Lan Subnet Availability Zone
+
+## 0.0.10 (2025-06-27)
+
+### Features 
+- Added automatic lookup for site_location
+- Added Routed_range handling 
+- Updated Variables for site_location and routed_range
+- Removed native_network variable as we are now inferring this value from `subnet_range_lan` 
+- Version Locked Sub-Module call
+- Updated Requirements for Provider and Terraform, adjusted versions file. 

--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,4 @@
+# Lookup data from region and VPC
+data "aws_availability_zones" "available" {
+  state = "available"
+}

--- a/main.tf
+++ b/main.tf
@@ -6,11 +6,6 @@ resource "aws_vpc" "cato-vpc" {
   })
 }
 
-# Lookup data from region and VPC
-data "aws_availability_zones" "available" {
-  state = "available"
-}
-
 # Internet Gateway and Attachment
 resource "aws_internet_gateway" "internet_gateway" {
   count = var.internet_gateway_id == null ? 1 : 0
@@ -240,19 +235,22 @@ resource "aws_route_table_association" "lan_subnet_route_table_association" {
 }
 
 module "vsocket-aws" {
-  source               = "catonetworks/vsocket-aws/cato"
-  vpc_id               = var.vpc_id == null ? aws_vpc.cato-vpc[0].id : var.vpc_id
-  key_pair             = var.key_pair
-  native_network_range = var.native_network_range
-  site_name            = var.site_name
-  site_description     = var.site_description
-  site_type            = var.site_type
-  mgmt_eni_id          = aws_network_interface.mgmteni.id
-  wan_eni_id           = aws_network_interface.waneni.id
-  lan_eni_id           = aws_network_interface.laneni.id
-  lan_local_ip         = var.lan_eni_ip
-  site_location        = var.site_location
-  tags                 = var.tags
-  license_id           = var.license_id
-  license_bw           = var.license_bw
+  source           = "catonetworks/vsocket-aws/cato"
+  version          = ">= 0.0.17"
+  vpc_id           = var.vpc_id == null ? aws_vpc.cato-vpc[0].id : var.vpc_id
+  key_pair         = var.key_pair
+  region           = var.region
+  subnet_range_lan = var.subnet_range_lan
+  site_name        = var.site_name
+  site_description = var.site_description
+  site_type        = var.site_type
+  mgmt_eni_id      = aws_network_interface.mgmteni.id
+  wan_eni_id       = aws_network_interface.waneni.id
+  lan_eni_id       = aws_network_interface.laneni.id
+  lan_local_ip     = var.lan_eni_ip
+  site_location    = var.site_location
+  tags             = var.tags
+  license_id       = var.license_id
+  license_bw       = var.license_bw
+  routed_networks  = var.routed_networks
 }

--- a/site_location_aws.tf
+++ b/site_location_aws.tf
@@ -1,0 +1,108 @@
+
+# Only run this data block if var.site_location is null
+# (Terraform does not support dynamic data blocks, so we use count)
+data "cato_siteLocation" "site_location" {
+  count = local.all_location_fields_null ? 1 : 0
+  filters = concat([
+    {
+      field     = "city"
+      operation = "exact"
+      search    = local.region_to_location[local.locationstr].city
+    },
+    {
+      field     = "country_name"
+      operation = "exact"
+      search    = local.region_to_location[local.locationstr].country
+    }
+    ],
+    local.region_to_location[local.locationstr].state != null ? [
+      {
+        field     = "state_name"
+        operation = "exact"
+        search    = local.region_to_location[local.locationstr].state
+      }
+  ] : [])
+}
+
+locals {
+  ## Check for all site_location inputs to be null
+  all_location_fields_null = (
+    var.site_location.city == null &&
+    var.site_location.country_code == null &&
+    var.site_location.state_code == null &&
+    var.site_location.timezone == null
+  ) ? true : false
+
+  ## If all site_location fields are null, use the data source to fetch the 
+  ## site_location from azure provuder location, else use var.site_location
+  cur_site_location = local.all_location_fields_null ? {
+    country_code = data.cato_siteLocation.site_location[0].locations[0].country_code
+    timezone     = data.cato_siteLocation.site_location[0].locations[0].timezone[0]
+    state_code   = data.cato_siteLocation.site_location[0].locations[0].state_code
+    city         = data.cato_siteLocation.site_location[0].locations[0].city
+  } : var.site_location
+
+  locationstr = lower(replace(var.region, " ", ""))
+  # Manual mapping of Azure regions to their cities and countries
+  # Since Azure doesn't provide city/country in the API, we create our own mapping
+  region_to_location = {
+    # North America - United States
+    "us-east-1"     = { city = "Ashburn", state = "Virginia", country = "United States", timezone = "UTC-5" }
+    "us-east-2"     = { city = "Columbus", state = "Ohio", country = "United States", timezone = "UTC-5" }
+    "us-west-1"     = { city = "San Francisco", state = "California", country = "United States", timezone = "UTC-8" }
+    "us-west-2"     = { city = "Boardman", state = "Oregon", country = "United States", timezone = "UTC-8" }
+    "us-gov-east-1" = { city = "Fairfax", state = "Virginia", country = "United States", timezone = "UTC-5" }
+    "us-gov-west-1" = { city = "Boardman", state = "Oregon", country = "United States", timezone = "UTC-8" }
+
+    # North America - Canada
+    "ca-central-1" = { city = "Montr\u00c3\u00a9al", state = null, country = "Canada", timezone = "UTC-5" }
+    "ca-west-1"    = { city = "Calgary", state = null, country = "Canada", timezone = "UTC-7" }
+
+    # North America - Mexico
+    "mx-central-1" = { city = "Austin", state = "Texas", country = "United States", timezone = "UTC-6" }
+
+    # Europe
+    "eu-central-1" = { city = "Frankfurt (Oder)", state = null, country = "Germany", timezone = "UTC+1" }
+    "eu-central-2" = { city = "Z\u00c3\u00bcrich", state = null, country = "Switzerland", timezone = "UTC+1" }
+    "eu-west-1"    = { city = "Dublin", state = null, country = "Ireland", timezone = "UTC+0" }
+    "eu-west-2"    = { city = "London", state = null, country = "United Kingdom", timezone = "UTC+0" }
+    "eu-west-3"    = { city = "Paris", state = null, country = "France", timezone = "UTC+1" }
+    "eu-north-1"   = { city = "Stockholm", state = null, country = "Sweden", timezone = "UTC+1" }
+    "eu-south-1"   = { city = "Milan", state = null, country = "Italy", timezone = "UTC+1" }
+    "eu-south-2"   = { city = "Madrid", state = null, country = "Spain", timezone = "UTC+1" }
+
+    # Asia Pacific
+    "ap-east-1"      = { city = "Hong Kong", state = null, country = "Hong Kong", timezone = "UTC+8" }
+    "ap-east-2"      = { city = "Taipei", state = null, country = "Taiwan", timezone = "UTC+8" }
+    "ap-south-1"     = { city = "Mumbai", state = "Maharashtra", country = "India", timezone = "UTC+5:30" }
+    "ap-south-2"     = { city = "Chennai", state = "Tamil Nadu", country = "India", timezone = "UTC+5:30" }
+    "ap-northeast-1" = { city = "Tokyo", state = null, country = "Japan", timezone = "UTC+9" }
+    "ap-northeast-2" = { city = "Seoul", state = null, country = "South Korea", timezone = "UTC+9" }
+    "ap-northeast-3" = { city = "Osaka", state = null, country = "Japan", timezone = "UTC+9" }
+    "ap-southeast-1" = { city = "Singapore", state = null, country = "Singapore", timezone = "UTC+8" }
+    "ap-southeast-2" = { city = "Sydney", state = "New South Wales", country = "Australia", timezone = "UTC+10" }
+    "ap-southeast-3" = { city = "Jakarta", state = null, country = "Indonesia", timezone = "UTC+7" }
+    "ap-southeast-4" = { city = "Melbourne", state = "Victoria", country = "Australia", timezone = "UTC+10" }
+    "ap-southeast-5" = { city = "Kuala Lumpur", state = null, country = "Malaysia", timezone = "UTC+8" }
+    "ap-southeast-7" = { city = "Bangkok", state = null, country = "Thailand", timezone = "UTC+7" }
+
+    # Middle East
+    "me-south-1"   = { city = "Manama", state = null, country = "Bahrain", timezone = "UTC+3" }
+    "me-central-1" = { city = "Dubai", state = null, country = "United Arab Emirates", timezone = "UTC+4" }
+    "il-central-1" = { city = "Tel Aviv", state = null, country = "Israel", timezone = "UTC+2" }
+
+    # Africa
+    "af-south-1" = { city = "Cape Town", state = null, country = "South Africa", timezone = "UTC+2" }
+
+    # South America
+    "sa-east-1" = { city = "S\u00c3\u00a3o Paulo", state = "S\u00c3\u00a3o Paulo", country = "Brazil", timezone = "UTC-3" }
+
+    # China (Isolated regions)
+    "cn-north-1"     = { city = "Beijing", state = null, country = "China", timezone = "UTC+8" }
+    "cn-northwest-1" = { city = "Beijing", state = null, country = "China", timezone = "UTC+8" }
+  }
+}
+
+output "site_location" {
+  value = data.cato_siteLocation.site_location
+}

--- a/variables.tf
+++ b/variables.tf
@@ -9,20 +9,28 @@ variable "site_description" {
   type        = string
 }
 
-variable "native_network_range" {
-  type        = string
-  description = <<EOT
-  	Choose a unique range for your new vsocket site that does not conflict with the rest of your Wide Area Network.
-    The accepted input format is Standard CIDR Notation, e.g. X.X.X.X/X
-	EOT
-}
-
 variable "vpc_network_range" {
   type        = string
   description = <<EOT
   	Choose a unique range for your new vpc where the vSocket will live.
     The accepted input format is Standard CIDR Notation, e.g. X.X.X.X/X
     EOT
+}
+
+variable "site_location" {
+  description = "Site location which is used by the Cato Socket to connect to the closest Cato PoP. If not specified, the location will be derived from the Azure region dynamicaly."
+  type = object({
+    city         = string
+    country_code = string
+    state_code   = string
+    timezone     = string
+  })
+  default = {
+    city         = null
+    country_code = null
+    state_code   = null ## Optional - for countries with states
+    timezone     = null
+  }
 }
 
 variable "site_type" {
@@ -33,15 +41,6 @@ variable "site_type" {
     condition     = contains(["DATACENTER", "BRANCH", "CLOUD_DC", "HEADQUARTERS"], var.site_type)
     error_message = "The site_type variable must be one of 'DATACENTER','BRANCH','CLOUD_DC','HEADQUARTERS'."
   }
-}
-
-variable "site_location" {
-  type = object({
-    city         = string
-    country_code = string
-    state_code   = string
-    timezone     = string
-  })
 }
 
 ## VPC Module Variables
@@ -141,4 +140,24 @@ variable "license_bw" {
   description = "The license bandwidth number for the cato site, specifying bandwidth ONLY applies for pooled licenses.  For a standard site license that is not pooled, leave this value null. Must be a number greater than 0 and an increment of 10."
   type        = string
   default     = null
+}
+
+variable "region" {
+  description = "AWS Region"
+  type        = string
+}
+
+
+variable "routed_networks" {
+  description = <<EOF
+  A map of routed networks to be accessed behind the vSocket site. The key is the network name and the value is the CIDR range.
+  Example: 
+  routed_networks = {
+  "Peered-VNET-1" = "10.100.1.0/24"
+  "On-Prem-Network" = "192.168.50.0/24"
+  "Management-Subnet" = "10.100.2.0/25"
+  }
+  EOF
+  type        = map(string)
+  default     = {} # Default to an empty map instead of null.
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,12 +1,13 @@
 terraform {
   required_providers {
+    cato = {
+      source  = "catonetworks/cato"
+      version = ">= 0.0.27"
+    }
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
-    }
-    cato = {
-      source = "catonetworks/cato"
+      version = ">= 5.98.00"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.5"
 }


### PR DESCRIPTION
## 0.0.10 (2025-06-27)

### Features 
- Added automatic lookup for site_location
- Added Routed_range handling 
- Updated Variables for site_location and routed_range
- Removed native_network variable as we are now inferring this value from `subnet_range_lan` 
- Version Locked Sub-Module call
- Updated Requirements for Provider and Terraform, adjusted versions file. 
